### PR TITLE
Editing CSS to disallow highlighting of text within the cards. Changing the cursor to pointer to make it more obvious that it's clickable.

### DIFF
--- a/src/app/game/game.component.scss
+++ b/src/app/game/game.component.scss
@@ -1,6 +1,14 @@
 .problem {
   position: relative;
   min-height: 200px;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none; 
+  user-select: none;
+  cursor: pointer;
+                                
 
   &__first, &__second, &__value {
     font-size: 3em;


### PR DESCRIPTION
The text becoming highlighted each time you click the card was a bit distracting. I fixed this by adding:

    -webkit-touch-callout: none;
    -webkit-user-select: none;
    -khtml-user-select: none;
    -moz-user-select: none;
    -ms-user-select: none; 
    user-select: none;

To the problem class. I also added:

    cursor: pointer

in order to make it more obvious that the cards are clickable.